### PR TITLE
update pdf.js for api update.

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
         </body>
 
         <script src="js/jquery.js"></script>
-        <script type="text/javascript" src="https://cdn.rawgit.com/mozilla/pdf.js/gh-pages/build/pdf.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.0.376/pdf.js"></script>
         <script src="ocrad.js"></script>
         <script src="http://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js"></script> 
         <script src="js/bootstrap.min.js"></script>


### PR DESCRIPTION
The old version of pdf.js does not work for current api. 
Replaced with a CDN source from the official repo(https://mozilla.github.io/pdf.js/getting_started/#download).